### PR TITLE
Add landing page with navigation and footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -1,0 +1,7 @@
+<footer class="site-footer">
+  <ul class="social-links">
+    <li><a href="https://www.linkedin.com/in/{{ site.linkedin_username }}" target="_blank">LinkedIn</a></li>
+    <li><a href="https://github.com/{{ site.github_username }}" target="_blank">GitHub</a></li>
+    <li><a href="https://twitter.com/{{ site.twitter_username }}" target="_blank">Twitter</a></li>
+  </ul>
+</footer>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,0 +1,8 @@
+<nav class="site-nav">
+  <ul class="nav-links">
+    <li><a href="{{ '/' | relative_url }}">Home</a></li>
+    <li><a href="{{ '/about/' | relative_url }}">About Me</a></li>
+    <li><a href="{{ '/research/' | relative_url }}">Research</a></li>
+    <li><a href="{{ '/blog/' | relative_url }}">Blog</a></li>
+  </ul>
+</nav>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>{{ page.title }} - {{ site.title }}</title>
+  <link rel="stylesheet" href="{{ '/assets/css/style.css' | relative_url }}">
+</head>
+<body>
+  {% include nav.html %}
+  <main class="page-content">
+    {{ content }}
+  </main>
+  {% include footer.html %}
+</body>
+</html>

--- a/about.md
+++ b/about.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: About Me
+permalink: /about/
+---
+
+# About Me
+
+A short bio will go here.

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,64 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+  display: flex;
+  min-height: 100vh;
+  flex-direction: column;
+}
+
+.site-nav {
+  background: #333;
+}
+
+.nav-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+}
+
+.nav-links li {
+  margin: 0;
+}
+
+.nav-links a {
+  display: block;
+  padding: 1rem;
+  color: #fff;
+  text-decoration: none;
+}
+
+.nav-links a:hover {
+  background: #555;
+}
+
+.page-content {
+  flex: 1;
+  padding: 1rem;
+}
+
+.site-footer {
+  background: #f5f5f5;
+  text-align: center;
+  padding: 1rem 0;
+}
+
+.social-links {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.social-links li {
+  display: inline-block;
+  margin: 0 0.5rem;
+}
+
+.social-links a {
+  text-decoration: none;
+  color: #333;
+}
+
+.social-links a:hover {
+  text-decoration: underline;
+}

--- a/index.md
+++ b/index.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Home
+---
+
+# Welcome
+
+This is the landing page for Mario's research and portfolio website.

--- a/research/index.md
+++ b/research/index.md
@@ -1,0 +1,9 @@
+---
+layout: default
+title: Research
+permalink: /research/
+---
+
+# Research
+
+Research articles will be listed here.


### PR DESCRIPTION
## Summary
- Introduce default layout with top navigation and footer
- Style navigation and footer and add landing, about, and research pages

## Testing
- `jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_688b3bab9c84832b9252d6f56bbcc3e6